### PR TITLE
add support for uint16/uint32 data types

### DIFF
--- a/src/convolve.ts
+++ b/src/convolve.ts
@@ -1,6 +1,6 @@
 import type { NdArray, TypedArray } from 'ndarray';
 
-export const convolve = (src: NdArray<TypedArray>, dst: NdArray<TypedArray>, filters: TypedArray, fixedFracBits: number) => {
+export const convolve = (src: NdArray<TypedArray | number[]>, dst: NdArray<TypedArray>, filters: TypedArray, fixedFracBits: number) => {
 	const [_, srcHeight] = src.shape;
 	const [dstWidth] = dst.shape;
 

--- a/src/convolve.ts
+++ b/src/convolve.ts
@@ -1,12 +1,13 @@
-import type { NdArray } from 'ndarray';
+import type { NdArray, TypedArray } from 'ndarray';
 
-const fixedFracBits = 14;
-
-const clamp = (v: number): number => v < 0 ? 0 : (v > 255 ? 255 : v);
-
-export const convolve = (src: NdArray, dst: NdArray, filters: Int16Array) => {
+export const convolve = (src: NdArray<TypedArray>, dst: NdArray<TypedArray>, filters: TypedArray, fixedFracBits: number) => {
 	const [_, srcHeight] = src.shape;
 	const [dstWidth] = dst.shape;
+
+	const maxValue = 2 ** (dst.data.BYTES_PER_ELEMENT * 8) - 1;
+	const clamp = (v: number): number => v < 0 ? 0 : (v > maxValue ? maxValue : v);
+	const fixedFracMul = 2 ** (fixedFracBits - 1);
+	const fixedFracMul2 = 2 * fixedFracMul;
 
 	// For each row
 	for (let srcY = 0; srcY < srcHeight; srcY++) {
@@ -41,10 +42,10 @@ export const convolve = (src: NdArray, dst: NdArray, filters: Int16Array) => {
 			// (!) Add 1/2 of value before clamping to get proper rounding. In other
 			// case brightness loss will be noticeable if you resize image with white
 			// border and place it on white background.
-			dst.set(dstX, dstY, 0, clamp( ( r + ( 1 << 13 ) ) >> fixedFracBits ) );
-			dst.set(dstX, dstY, 1, clamp( ( g + ( 1 << 13 ) ) >> fixedFracBits ) );
-			dst.set(dstX, dstY, 2, clamp( ( b + ( 1 << 13 ) ) >> fixedFracBits ) );
-			dst.set(dstX, dstY, 3, clamp( ( a + ( 1 << 13 ) ) >> fixedFracBits ) );
+			dst.set(dstX, dstY, 0, clamp( ( r + fixedFracMul ) / fixedFracMul2 ) );
+			dst.set(dstX, dstY, 1, clamp( ( g + fixedFracMul ) / fixedFracMul2 ) );
+			dst.set(dstX, dstY, 2, clamp( ( b + fixedFracMul ) / fixedFracMul2 ) );
+			dst.set(dstX, dstY, 3, clamp( ( a + fixedFracMul ) / fixedFracMul2 ) );
 		}
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,10 +54,10 @@ function resize(
 	convolve(tmp, dstTranspose, filtersY, fixedFracBits);
 }
 
-export function lanczos3(src: NdArray<SupportedTypes>, dst: NdArray<SupportedTypes>): void {
+export function lanczos3(src: NdArray<SupportedTypes | number[]>, dst: NdArray<SupportedTypes>): void {
 	resize(src, dst, Method.LANCZOS_3);
 }
 
-export function lanczos2(src: NdArray<SupportedTypes>, dst: NdArray<SupportedTypes>): void {
+export function lanczos2(src: NdArray<SupportedTypes | number[]>, dst: NdArray<SupportedTypes>): void {
 	resize(src, dst, Method.LANCZOS_2);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,10 @@ enum Method {
 
 export type SupportedTypes = Uint8Array | Uint8ClampedArray | Uint16Array | Uint32Array
 
-function resize(src: NdArray<SupportedTypes>, dst: NdArray<SupportedTypes>, method: Method): void {
+function resize(
+	src: NdArray<SupportedTypes | number[]>,
+	dst: NdArray<SupportedTypes>, method: Method
+): void {
 	if (src.shape.length !== 3 || dst.shape.length !== 3)
 		throw new TypeError
 			('Input and output must have exactly 3 dimensions (width, height and colorspace)');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import ndarray, { NdArray } from 'ndarray';
-import { filters } from '../vendor/filters';
+import ndarray, { NdArray, TypedArray } from 'ndarray';
+import { filters, TypedArrayConstructor } from '../vendor/filters';
 import { convolve } from './convolve';
 
 enum Method {
@@ -7,28 +7,48 @@ enum Method {
 	LANCZOS_2 = 2,
 }
 
-function resize(src: NdArray, dst: NdArray, method: Method): void {
+function resize(src: NdArray<TypedArray>, dst: NdArray<TypedArray>, method: Method): void {
 	const [srcWidth, srcHeight] = src.shape;
 	const [dstWidth, dstHeight] = dst.shape;
 
 	const ratioX = dstWidth / srcWidth;
 	const ratioY = dstHeight / srcHeight;
 
-	const filtersX = filters(srcWidth, dstWidth, ratioX, 0, method === Method.LANCZOS_2);
-	const filtersY = filters(srcHeight, dstHeight, ratioY, 0, method === Method.LANCZOS_2);
+	let floatType, intType;
+	switch (dst.dtype) {
+		case 'uint8_clamped':
+		case 'uint8':
+			floatType = Float32Array;
+			intType = Int16Array;
+			break;
+		case 'uint16':
+		case 'uint32':
+			floatType = Float64Array;
+			intType = Int32Array;
+			break;
+		default:
+			throw TypeError(`Unsupported data type ${dst.dtype}`);
+	}
+	const fixedFracBits = intType.BYTES_PER_ELEMENT * 7;
 
-	const tmp = ndarray(new Uint8Array(dstWidth * srcHeight * 4), [srcHeight, dstWidth, 4]);
+	const filtersX = filters(srcWidth, dstWidth, ratioX, 0, method === Method.LANCZOS_2,
+		floatType, intType, fixedFracBits);
+	const filtersY = filters(srcHeight, dstHeight, ratioY, 0, method === Method.LANCZOS_2,
+		floatType, intType, fixedFracBits);
+
+	const constructor = dst.data.constructor as TypedArrayConstructor;
+	const tmp = ndarray(new constructor(dstWidth * srcHeight * 4), [srcHeight, dstWidth, 4]);
 	const tmpTranspose = tmp.transpose(1, 0);
 	const dstTranspose = dst.transpose(1, 0);
 
-	convolve(src, tmpTranspose, filtersX);
-	convolve(tmp, dstTranspose, filtersY);
+	convolve(src, tmpTranspose, filtersX, fixedFracBits);
+	convolve(tmp, dstTranspose, filtersY, fixedFracBits);
 }
 
-export function lanczos3(src: NdArray, dst: NdArray): void {
+export function lanczos3(src: NdArray<TypedArray>, dst: NdArray<TypedArray>): void {
 	resize(src, dst, Method.LANCZOS_3);
 }
 
-export function lanczos2(src: NdArray, dst: NdArray): void {
+export function lanczos2(src: NdArray<TypedArray>, dst: NdArray<TypedArray>): void {
 	resize(src, dst, Method.LANCZOS_2);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,10 @@ enum Method {
 export type SupportedTypes = Uint8Array | Uint8ClampedArray | Uint16Array | Uint32Array
 
 function resize(src: NdArray<SupportedTypes>, dst: NdArray<SupportedTypes>, method: Method): void {
+	if (src.shape.length !== 3 || dst.shape.length !== 3)
+		throw new TypeError
+			('Input and output must have exactly 3 dimensions (width, height and colorspace)');
+
 	const [srcWidth, srcHeight] = src.shape;
 	const [dstWidth, dstHeight] = dst.shape;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,9 @@ enum Method {
 	LANCZOS_2 = 2,
 }
 
-function resize(src: NdArray<TypedArray>, dst: NdArray<TypedArray>, method: Method): void {
+export type SupportedTypes = Uint8Array | Uint8ClampedArray | Uint16Array | Uint32Array
+
+function resize(src: NdArray<SupportedTypes>, dst: NdArray<SupportedTypes>, method: Method): void {
 	const [srcWidth, srcHeight] = src.shape;
 	const [dstWidth, dstHeight] = dst.shape;
 
@@ -45,10 +47,10 @@ function resize(src: NdArray<TypedArray>, dst: NdArray<TypedArray>, method: Meth
 	convolve(tmp, dstTranspose, filtersY, fixedFracBits);
 }
 
-export function lanczos3(src: NdArray<TypedArray>, dst: NdArray<TypedArray>): void {
+export function lanczos3(src: NdArray<SupportedTypes>, dst: NdArray<SupportedTypes>): void {
 	resize(src, dst, Method.LANCZOS_3);
 }
 
-export function lanczos2(src: NdArray<TypedArray>, dst: NdArray<TypedArray>): void {
+export function lanczos2(src: NdArray<SupportedTypes>, dst: NdArray<SupportedTypes>): void {
 	resize(src, dst, Method.LANCZOS_2);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import ndarray, { NdArray, TypedArray } from 'ndarray';
+import ndarray, { NdArray } from 'ndarray';
 import { filters, TypedArrayConstructor } from '../vendor/filters';
 import { convolve } from './convolve';
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -75,14 +75,16 @@ test('resize down - lanczos3 non-square', async (t) => {
 
 test('upscale Uint16 data', async (t) => {
 	const pattern = ndarray(new Uint16Array([
-		0, 500, 1000, 500,
-		0, 500, 1000, 500
-	]), [ 2, 4, 1 ])
-	const output = ndarray(new Uint16Array(12), [2, 6, 1])
+		0,   500, 1000, 500,
+		500, 500, 500,  500,
+		0,   500, 1000, 500
+	]), [ 3, 4, 1 ])
+	const output = ndarray(new Uint16Array(18), [3, 6, 1])
 	const expected = ndarray(new Uint16Array([
-		0, 164, 640, 1011, 764, 440,
-		0, 164, 640, 1011, 764, 440
-	]), [2, 6, 1])
+		0,   164, 640, 1011, 764, 440,
+		500, 500, 500, 500,  500, 500,
+		0,   164, 640, 1011, 764, 440
+	]), [3, 6, 1])
 
 	lanczos3(pattern, output);
 
@@ -94,14 +96,16 @@ test('upscale Uint16 data', async (t) => {
 
 test('downscale Uint16 data', async (t) => {
 	const pattern = ndarray(new Uint16Array([
-		0, 164, 640, 1011, 764, 440,
-		0, 164, 640, 1011, 764, 440
-	]), [2, 6, 1]);
-	const output = ndarray(new Uint16Array(8), [2, 4, 1]);
+		0,   164, 640, 1011, 764, 440,
+		500, 500, 500,  500, 500, 500,
+		0,   164, 640, 1011, 764, 440
+	]), [3, 6, 1]);
+	const output = ndarray(new Uint16Array(12), [3, 4, 1]);
 	const expected = ndarray(new Uint16Array([
-		6, 520, 969, 525,
-		6, 520, 969, 525
-	]), [2, 4, 1]);
+		6,   520, 969, 525,
+		500, 500, 500, 500,
+		6,   520, 969, 525
+	]), [3, 4, 1]);
 
 	lanczos3(pattern, output);
 
@@ -113,14 +117,16 @@ test('downscale Uint16 data', async (t) => {
 
 test('upscale Uint32 data', async (t) => {
 	const pattern = ndarray(new Uint32Array([
-		0, 500, 1000, 500,
-		0, 500, 1000, 500
-	]), [2, 4, 1]);
-	const output = ndarray(new Uint32Array(12), [2, 6, 1]);
+		0,   500, 1000, 500,
+		500, 500,  500, 500,
+		0,   500, 1000, 500
+	]), [3, 4, 1]);
+	const output = ndarray(new Uint32Array(18), [3, 6, 1]);
 	const expected = ndarray(new Uint32Array([
-		0, 164, 640, 1011, 764, 440,
-		0, 164, 640, 1011, 764, 440
-	]), [2, 6, 1]);
+		0,   164, 640, 1011, 764, 440,
+		500, 500, 500,  500, 500, 500,
+		0,   164, 640, 1011, 764, 440
+	]), [3, 6, 1]);
 
 	lanczos3(pattern, output);
 
@@ -132,14 +138,16 @@ test('upscale Uint32 data', async (t) => {
 
 test('downscale Uint32 data', async (t) => {
 	const pattern = ndarray(new Uint32Array([
-		0, 164, 640, 1011, 764, 440,
-		0, 164, 640, 1011, 764, 440
-	]), [2, 6, 1]);
-	const output = ndarray(new Uint32Array(8), [2, 4, 1]);
+		0,   164, 640, 1011, 764, 440,
+		500, 500, 500,  500, 500, 500,
+		0,   164, 640, 1011, 764, 440
+	]), [3, 6, 1]);
+	const output = ndarray(new Uint32Array(12), [3, 4, 1]);
 	const expected = ndarray(new Uint32Array([
-		6, 520, 969, 525,
-		6, 520, 969, 525
-	]), [2, 4, 1]);
+		6,   520, 969, 525,
+		500, 500, 500, 500,
+		6,   520, 969, 525
+	]), [3, 4, 1]);
 
 	lanczos3(pattern, output);
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,24 +1,24 @@
 require('source-map-support').install();
 
-import ndarray from 'ndarray';
+import ndarray, { TypedArray } from 'ndarray';
 import { getPixels } from 'ndarray-pixels';
 import test from 'tape';
 import { lanczos2, lanczos3 } from '../';
 
-const createImage = (w: number, h: number): ndarray.NdArray => {
+const createImage = (w: number, h: number): ndarray.NdArray<Uint8Array> => {
 	const image = ndarray(new Uint8Array(w * h * 4).fill(0), [h, w, 4]);
 	return image.transpose(1, 0); // https://github.com/scijs/get-pixels/issues/52
 };
 
-const FIXTURES: Promise<Record<string, ndarray.NdArray>> = new Promise(async (resolve, reject) => {
+const FIXTURES: Promise<Record<string, ndarray.NdArray<Uint8Array>>> = new Promise(async (resolve, reject) => {
 	try {
 		resolve({
-			pattern: await getPixels(`${__dirname}/fixtures/pattern.png`),
-			patternTiled: await getPixels(`${__dirname}/fixtures/pattern-tiled.png`),
-			expectedPatternHalf: await getPixels(`${__dirname}/fixtures/pattern-half.png`),
-			expectedPatternHalf2: await getPixels(`${__dirname}/fixtures/pattern-half-2.png`),
-			expectedPatternDouble: await getPixels(`${__dirname}/fixtures/pattern-double.png`),
-			expectedPatternTiledHalf: await getPixels(`${__dirname}/fixtures/pattern-tiled-half.png`),
+			pattern: await getPixels(`${__dirname}/fixtures/pattern.png`) as ndarray.NdArray<Uint8Array>,
+			patternTiled: await getPixels(`${__dirname}/fixtures/pattern-tiled.png`) as ndarray.NdArray<Uint8Array>,
+			expectedPatternHalf: await getPixels(`${__dirname}/fixtures/pattern-half.png`) as ndarray.NdArray<Uint8Array>,
+			expectedPatternHalf2: await getPixels(`${__dirname}/fixtures/pattern-half-2.png`) as ndarray.NdArray<Uint8Array>,
+			expectedPatternDouble: await getPixels(`${__dirname}/fixtures/pattern-double.png`) as ndarray.NdArray<Uint8Array>,
+			expectedPatternTiledHalf: await getPixels(`${__dirname}/fixtures/pattern-tiled-half.png`) as ndarray.NdArray<Uint8Array>,
 		});
 	} catch (e) {
 		reject(e);
@@ -26,7 +26,7 @@ const FIXTURES: Promise<Record<string, ndarray.NdArray>> = new Promise(async (re
 });
 
 test('resize down - lanczos3', async (t) => {
-	const {pattern, expectedPatternHalf} = await FIXTURES;
+	const { pattern, expectedPatternHalf } = await FIXTURES;
 	let patternHalf = createImage(4, 4);
 
 	lanczos3(pattern, patternHalf);
@@ -38,7 +38,7 @@ test('resize down - lanczos3', async (t) => {
 });
 
 test('resize down - lanczos2', async (t) => {
-	const {pattern, expectedPatternHalf2} = await FIXTURES;
+	const { pattern, expectedPatternHalf2 } = await FIXTURES;
 	const patternHalf = createImage(4, 4);
 
 	lanczos2(pattern, patternHalf);
@@ -50,7 +50,7 @@ test('resize down - lanczos2', async (t) => {
 });
 
 test('resize up - lanczos3', async (t) => {
-	const {pattern, expectedPatternDouble} = await FIXTURES;
+	const { pattern, expectedPatternDouble } = await FIXTURES;
 	const patternDouble = createImage(16, 16);
 
 	lanczos3(pattern, patternDouble);
@@ -62,7 +62,7 @@ test('resize up - lanczos3', async (t) => {
 });
 
 test('resize down - lanczos3 non-square', async (t) => {
-	const {patternTiled, expectedPatternTiledHalf} = await FIXTURES;
+	const { patternTiled, expectedPatternTiledHalf } = await FIXTURES;
 	const patternTiledHalf = createImage(16, 4);
 
 	lanczos3(patternTiled, patternTiledHalf);
@@ -70,5 +70,81 @@ test('resize down - lanczos3 non-square', async (t) => {
 	t.deepEqual(patternTiledHalf.shape, expectedPatternTiledHalf.shape, 'shape');
 	t.deepEqual(patternTiledHalf.stride, expectedPatternTiledHalf.stride, 'stride');
 	t.deepEqual(patternTiledHalf, expectedPatternTiledHalf, 'data');
+	t.end();
+});
+
+test('upscale Uint16 data', async (t) => {
+	const pattern = ndarray(new Uint16Array([
+		0, 500, 1000, 500,
+		0, 500, 1000, 500
+	]), [ 2, 4, 1 ])
+	const output = ndarray(new Uint16Array(12), [2, 6, 1])
+	const expected = ndarray(new Uint16Array([
+		0, 164, 640, 1011, 764, 440,
+		0, 164, 640, 1011, 764, 440
+	]), [2, 6, 1])
+
+	lanczos3(pattern, output);
+
+	t.deepEqual(output.shape, expected.shape, 'shape');
+	t.deepEqual(output.stride, expected.stride, 'stride');
+	t.deepEqual(output, expected, 'data');
+	t.end();
+});
+
+test('downscale Uint16 data', async (t) => {
+	const pattern = ndarray(new Uint16Array([
+		0, 164, 640, 1011, 764, 440,
+		0, 164, 640, 1011, 764, 440
+	]), [2, 6, 1]);
+	const output = ndarray(new Uint16Array(8), [2, 4, 1]);
+	const expected = ndarray(new Uint16Array([
+		6, 520, 969, 525,
+		6, 520, 969, 525
+	]), [2, 4, 1]);
+
+	lanczos3(pattern, output);
+
+	t.deepEqual(output.shape, expected.shape, 'shape');
+	t.deepEqual(output.stride, expected.stride, 'stride');
+	t.deepEqual(output, expected, 'data');
+	t.end();
+});
+
+test('upscale Uint32 data', async (t) => {
+	const pattern = ndarray(new Uint32Array([
+		0, 500, 1000, 500,
+		0, 500, 1000, 500
+	]), [2, 4, 1]);
+	const output = ndarray(new Uint32Array(12), [2, 6, 1]);
+	const expected = ndarray(new Uint32Array([
+		0, 164, 640, 1011, 764, 440,
+		0, 164, 640, 1011, 764, 440
+	]), [2, 6, 1]);
+
+	lanczos3(pattern, output);
+
+	t.deepEqual(output.shape, expected.shape, 'shape');
+	t.deepEqual(output.stride, expected.stride, 'stride');
+	t.deepEqual(output, expected, 'data');
+	t.end();
+});
+
+test('downscale Uint32 data', async (t) => {
+	const pattern = ndarray(new Uint32Array([
+		0, 164, 640, 1011, 764, 440,
+		0, 164, 640, 1011, 764, 440
+	]), [2, 6, 1]);
+	const output = ndarray(new Uint32Array(8), [2, 4, 1]);
+	const expected = ndarray(new Uint32Array([
+		6, 520, 969, 525,
+		6, 520, 969, 525
+	]), [2, 4, 1]);
+
+	lanczos3(pattern, output);
+
+	t.deepEqual(output.shape, expected.shape, 'shape');
+	t.deepEqual(output.stride, expected.stride, 'stride');
+	t.deepEqual(output, expected, 'data');
 	t.end();
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,6 @@
 require('source-map-support').install();
 
-import ndarray, { TypedArray } from 'ndarray';
+import ndarray from 'ndarray';
 import { getPixels } from 'ndarray-pixels';
 import test from 'tape';
 import { lanczos2, lanczos3 } from '../';

--- a/vendor/filters.ts
+++ b/vendor/filters.ts
@@ -11,7 +11,7 @@ const filterValue = ( x: number, a: 2 | 3 ) => {
 	const xPi = x * Math.PI
 
 	return ( Math.sin( xPi ) / xPi ) * Math.sin( xPi / a ) / ( xPi / a )
-};
+}
 
 export const filters = (
 	srcSize: number,
@@ -23,7 +23,7 @@ export const filters = (
 	intType: TypedArrayConstructor,
 	fixedFracBits: number
 ) => {
-	const mul = (2 ** fixedFracBits) - 1;
+	const mul = (2 ** fixedFracBits) - 1
 	const toFixedPoint = (value: number) => Math.round(value * mul)
 
 	const a = use2 ? 2 : 3


### PR DESCRIPTION
Normally it should not have any other effect on Uint8 arrays except the fact that I had to replace one shift left with a multiplication (which on a modern CPU is about the same) and one shift right with a division - which - alas - is quite slower.

JS has 53 bit integers but bit shift operations are limited to 32 bits...

Resolves #98 